### PR TITLE
feat: break ngx-datable by using NxDatatableModule

### DIFF
--- a/swimlanengx-datatable-ngcc/src/app/app.module.ts
+++ b/swimlanengx-datatable-ngcc/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
-import '@swimlane/ngx-datatable';
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { AppComponent } from './app.component';
 
@@ -10,7 +10,8 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [
-    BrowserModule
+    BrowserModule,
+    NgxDatatableModule
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Using ng `8.2.0-rc.0`, `ngx-datatable` is breaking in one of our Ivy apps with:
```
ERROR in node_modules/@swimlane/ngx-datatable/release/datatable.module.d.ts:1:22 - error TS-996002: Appears in the NgModule.imports of AdminModule, but could not be resolved to an NgModule class

1 export declare class NgxDatatableModule {
```

This PR should reproduce the build failure.