### PR TITLE
ci: fine tune renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,13 @@
 {
   "extends": [
-    "config:base"
+    "schedule:nonOfficeHours"
   ],
+  "semanticCommits": true,
+  "semanticPrefix": "build",
+  "commitMessage": "{{semanticPrefix}} update {{depName}} to version {{newVersion}}",
+  "separateMajorMinor": false,
+  "prHourlyLimit": 2,
   "timezone": "America/Tijuana",
-  "schedule": [
-    "after 10pm every weekday",
-    "before 4am every weekday",
-    "every weekend"
-  ],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
`config:base` extends a number of presents https://renovatebot.com/docs/presets-config/ which are not needed for this use case.

Hence, use renovate defaults and just extend from `schedule:nonOfficeHours`