### PR TITLE
ci: enable renovate master issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "schedule:nonOfficeHours"
   ],
+  "masterIssue": true,
   "semanticCommits": true,
   "semanticPrefix": "build",
   "commitMessage": "{{semanticPrefix}} update {{depName}} to version {{newVersion}}",


### PR DESCRIPTION
This will result in a single "master issue" being created in the repo that lets you view all upcoming and open PRs from Renovate and also to override any schedules to force open updates that would otherwise have to wait.