### PR TITLE
ci: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,16 @@
   ],
   "masterIssue": true,
   "semanticCommits": true,
-  "semanticPrefix": "build",
-  "commitMessage": "{{semanticPrefix}} update {{depName}} to version {{newVersion}}",
+  "semanticCommitType": "build",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "timezone": "America/Tijuana",
   "packageRules": [
+    {
+      "managers": ["npm"],
+      "updateTypes": ["digest"],
+      "enabled": false
+    },
     {
       "packagePatterns": [
         "^@angular.*"
@@ -30,7 +34,7 @@
         "minor",
         "major"
       ],
-      "enabled": false
+      "masterIssueApproval": true
     }
   ]
 }


### PR DESCRIPTION
Applies following changes:
- Simplify semantic commit message config to ensure proper commit messages
- Disables digest updates for npm packages (seems to be causing performance issues with npm)
- Changes TS minor/major from disabled to requires approval (better to have them visible)