### PR TITLE
ci: enable npm digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     {
       "managers": ["npm"],
       "updateTypes": ["digest"],
-      "enabled": false
+      "enabled": true
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
We moved to yarn which should be faster let’s try to enable digest updates again so that we Angular snapshots are updated automatically.

If we see that we don’t get renovate updates we should revert this commit.