### PR TITLE
Configure devextreme-angular properly

### DIFF
--- a/infra/passing.json
+++ b/infra/passing.json
@@ -55,6 +55,7 @@
   "covalentmarkdown-ngcc",
   "datoramaakita-ngcc",
   "delonauth-ngcc",
+  "devextreme-angular-ngcc",
   "fortawesomeangular-fontawesome-ngcc",
   "highcharts-angular-ngcc",
   "ionicangular-ngcc",

--- a/projects/devextreme-angular-ngcc/tsconfig.app.json
+++ b/projects/devextreme-angular-ngcc/tsconfig.app.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
-    "types": []
+    "types": [],
+    "paths": {
+      "jszip": ["./node_modules/jszip/dist/jszip.js"]
+    }
   },
   "files": [
     "src/main.ts",


### PR DESCRIPTION
This package would previously fail to compile as its dependency on
`devextreme` > `jszip` was not configured properly, resulting in the
build error: `Module not found: Error: Can't resolve 'stream'`.

The documentation of `dexextreme` describes a fix for this issue, which
is to map the `jszip` import to its dist bundle.