### PR TITLE
ng2-file-upload: Import FileUploadModule into AppModule

### DIFF
--- a/projects/ng2-file-upload-ngcc/src/app/app.module.ts
+++ b/projects/ng2-file-upload-ngcc/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
-import 'ng2-file-upload';
+import { FileUploadModule } from 'ng2-file-upload';
 
 import { AppComponent } from './app.component';
 
@@ -10,7 +10,8 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [
-    BrowserModule
+    BrowserModule,
+    FileUploadModule,
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
```
ERROR in ../../node_modules/ng2-file-upload/file-upload/file-upload.module.d.ts:1:22 - error TS-996002: Appears in the NgModule.imports of AppModule, but could not be resolved to an NgModule class
```